### PR TITLE
feat: Longest Common Subsequence — O(m*n) 2D DP solution

### DIFF
--- a/dynamic_programming/NOTES.md
+++ b/dynamic_programming/NOTES.md
@@ -27,3 +27,12 @@
 - **Key insight:** At each house, max = max(skip current = prev1,
   rob current = prev2 + num). Roll variables forward each step.
 - **Edge cases:** Empty array returns 0, single house returns nums[0]
+
+
+## Longest Common Subsequence
+- **Approach:** Bottom-up 2D DP table of size (m+1) x (n+1)
+- **Time:** O(m * n) — fill entire table
+- **Space:** O(m * n) — full DP table stored
+- **Key insight:** If chars match → dp[i][j] = dp[i-1][j-1] + 1
+  If no match → dp[i][j] = max(dp[i-1][j], dp[i][j-1])
+- **Optimization:** Can reduce to O(n) space using two rolling rows

--- a/dynamic_programming/longest_common_subsequence.py
+++ b/dynamic_programming/longest_common_subsequence.py
@@ -1,0 +1,39 @@
+def longest_common_subsequence(text1: str, text2: str) -> int:
+    """
+    Given two strings, return the length of their longest common
+    subsequence. A subsequence appears in the same relative order
+    but not necessarily contiguous.
+
+    Approach: Bottom-up 2D DP table. If characters match, extend
+    the previous diagonal. Otherwise take the max of left or above.
+
+    Time Complexity: O(m * n)
+    Space Complexity: O(m * n)
+
+    Examples:
+    >>> longest_common_subsequence("abcde", "ace")
+    3
+    >>> longest_common_subsequence("abc", "abc")
+    3
+    >>> longest_common_subsequence("abc", "def")
+    0
+    >>> longest_common_subsequence("bl", "yby")
+    1
+    """
+    m, n = len(text1), len(text2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if text1[i - 1] == text2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+
+    return dp[m][n]
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+    print("All tests passed.")


### PR DESCRIPTION
## Problem
Given two strings, return the length of their longest common
subsequence. A subsequence appears in the same relative order
but not necessarily contiguous.

## Approach
Bottom-up 2D DP table of size (m+1) x (n+1). At each cell:
- Characters match → dp[i][j] = dp[i-1][j-1] + 1
- No match → dp[i][j] = max(dp[i-1][j], dp[i][j-1])
Final answer is at dp[m][n].

## Complexity
- Time: O(m * n) — fill entire DP table
- Space: O(m * n) — full table stored

## Closes
Closes #23 