### PR TITLE
feat: Number of Islands — O(m*n) DFS solution

### DIFF
--- a/graphs/NOTES.md
+++ b/graphs/NOTES.md
@@ -1,0 +1,12 @@
+# Graphs
+
+## Number of Islands
+- **Approach:** DFS from each unvisited land cell, mark visited
+  cells as '0' to avoid revisiting
+- **Time:** O(m * n) — each cell visited at most once
+- **Space:** O(m * n) — recursion stack depth in worst case
+  (entire grid is one island)
+- **Key insight:** Each DFS call floods an entire island — count
+  how many times we trigger DFS = number of islands
+- **Note:** Modifies the input grid in place. Pass a deep copy
+  if original grid must be preserved.

--- a/graphs/number_of_islands.py
+++ b/graphs/number_of_islands.py
@@ -1,0 +1,61 @@
+def num_islands(grid: list[list[str]]) -> int:
+    """
+    Given an m x n grid of '1's (land) and '0's (water), return
+    the number of islands. An island is formed by connecting
+    adjacent lands horizontally or vertically.
+
+    Approach: DFS — for each unvisited land cell, trigger a DFS
+    that marks all connected land cells as visited ('0').
+    Count how many times DFS is triggered = number of islands.
+
+    Time Complexity: O(m * n) — visit each cell at most once
+    Space Complexity: O(m * n) — recursion stack in worst case
+
+    Examples:
+    >>> num_islands([
+    ...     ["1","1","1","1","0"],
+    ...     ["1","1","0","1","0"],
+    ...     ["1","1","0","0","0"],
+    ...     ["0","0","0","0","0"]
+    ... ])
+    1
+    >>> num_islands([
+    ...     ["1","1","0","0","0"],
+    ...     ["1","1","0","0","0"],
+    ...     ["0","0","1","0","0"],
+    ...     ["0","0","0","1","1"]
+    ... ])
+    3
+    >>> num_islands([["0","0","0"]])
+    0
+    >>> num_islands([["1"]])
+    1
+    """
+    if not grid:
+        return 0
+
+    rows, cols = len(grid), len(grid[0])
+    count = 0
+
+    def dfs(r: int, c: int) -> None:
+        if r < 0 or r >= rows or c < 0 or c >= cols or grid[r][c] == "0":
+            return
+        grid[r][c] = "0"
+        dfs(r + 1, c)
+        dfs(r - 1, c)
+        dfs(r, c + 1)
+        dfs(r, c - 1)
+
+    for r in range(rows):
+        for c in range(cols):
+            if grid[r][c] == "1":
+                count += 1
+                dfs(r, c)
+
+    return count
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+    print("All tests passed.")


### PR DESCRIPTION
## Problem
Given an m x n grid of '1's and '0's, return the number of islands.
Islands are formed by connecting adjacent land cells horizontally
or vertically.

## Approach
DFS with in-place marking. For each unvisited land cell ('1'),
increment count and trigger DFS that marks all connected land
cells as '0' to prevent revisiting. Each DFS call completely
floods one island.

## Complexity
- Time: O(m * n) — each cell visited at most once
- Space: O(m * n) — recursion stack worst case

## Note
Modifies input grid in place. Pass a deep copy to preserve original.

## Closes
Closes #29 