### PR TITLE
feat: Quick Sort — O(n log n) divide and conquer solution

### DIFF
--- a/sorting/NOTES.md
+++ b/sorting/NOTES.md
@@ -18,3 +18,14 @@
 - **Key insight:** Split until base case (1 element), then merge
   pairs in sorted order back up the call stack
 - **Advantage over Bubble Sort:** Guaranteed O(n log n) vs O(n²)
+
+## Quick Sort
+- **Approach:** Recursive divide and conquer, last element as pivot
+- **Time Best/Avg:** O(n log n) — balanced partitions
+- **Time Worst:** O(n²) — already sorted input, poor pivot choice
+- **Space:** O(n log n) — recursion stack depth
+- **Stable:** No — equal elements may change relative order
+- **Key insight:** Pivot ends up in its final sorted position after
+  each partition step
+- **vs Merge Sort:** Quick Sort faster in practice (cache friendly)
+  but not guaranteed O(n log n) like Merge Sort

--- a/sorting/quick_sort.py
+++ b/sorting/quick_sort.py
@@ -1,0 +1,42 @@
+def quick_sort(arr: list[int]) -> list[int]:
+    """
+    Sort a list using Quick Sort — select a pivot, partition the
+    array so smaller elements go left and larger go right, then
+    recursively sort both partitions.
+
+    Approach: Recursive with last element as pivot (Lomuto scheme).
+    Returns a new sorted list without modifying the original.
+
+    Time Complexity:
+        Best Case:    O(n log n) — balanced partitions
+        Average Case: O(n log n)
+        Worst Case:   O(n²)     — already sorted, poor pivot choice
+    Space Complexity: O(n log n) — recursion stack
+    Stable: No
+
+    Examples:
+    >>> quick_sort([10, 7, 8, 9, 1, 5])
+    [1, 5, 7, 8, 9, 10]
+    >>> quick_sort([1, 2, 3, 4, 5])
+    [1, 2, 3, 4, 5]
+    >>> quick_sort([5, 4, 3, 2, 1])
+    [1, 2, 3, 4, 5]
+    >>> quick_sort([1])
+    [1]
+    >>> quick_sort([])
+    []
+    """
+    if len(arr) <= 1:
+        return arr
+
+    pivot = arr[-1]
+    left = [x for x in arr[:-1] if x <= pivot]
+    right = [x for x in arr[:-1] if x > pivot]
+
+    return quick_sort(left) + [pivot] + quick_sort(right)
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+    print("All tests passed.")


### PR DESCRIPTION
## Problem
Implement Quick Sort — select a pivot, partition array around it,
recursively sort both partitions.

## Approach
Recursive with last element as pivot. List comprehensions split
elements into left (<=pivot) and right (>pivot) partitions.
Returns a new sorted list — does not modify original input.

## Complexity
- Time Best/Avg: O(n log n) — balanced partitions
- Time Worst: O(n²) — already sorted, poor pivot choice
- Space: O(n log n) — recursion stack
- Stable: No

## Closes
Closes #33 