### PR TITLE
feat: Word Search — backtracking DFS solution

### DIFF
--- a/graphs/NOTES.md
+++ b/graphs/NOTES.md
@@ -20,3 +20,14 @@
   prevents infinite recursion
 - **Difference from Number of Islands:** Fills with a new value
   instead of marking visited, works on integers not strings
+
+  ## Word Search
+- **Approach:** Backtracking DFS from every cell as starting point
+- **Time:** O(m * n * 4^L) — L = word length, 4 directions each step
+- **Space:** O(L) — recursion stack depth = word length
+- **Key insight:** Mark visited cells with "#" temporarily to prevent
+  reuse in same path. Restore original value after backtracking.
+- **Early exit:** Return True as soon as word is found — no need
+  to explore remaining cells
+- **vs Flood Fill/Islands:** Uses backtracking to restore state,
+  not permanent marking

--- a/graphs/word_search.py
+++ b/graphs/word_search.py
@@ -1,0 +1,59 @@
+def exist(board: list[list[str]], word: str) -> bool:
+    """
+    Given an m x n grid of characters and a word, return True if
+    the word exists in the grid. Word can be constructed from
+    sequentially adjacent cells (horizontal or vertical).
+    The same cell cannot be used more than once.
+
+    Approach: Backtracking DFS — try each cell as starting point,
+    explore all 4 directions recursively, mark visited cells
+    temporarily and restore after backtracking.
+
+    Time Complexity: O(m * n * 4^len(word))
+    Space Complexity: O(len(word)) — recursion stack depth
+
+    Examples:
+    >>> exist([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "ABCCED")
+    True
+    >>> exist([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "SEE")
+    True
+    >>> exist([["A","B","C","E"],["S","F","C","S"],["A","D","E","E"]], "ABCB")
+    False
+    >>> exist([["a"]], "a")
+    True
+    """
+    rows, cols = len(board), len(board[0])
+
+    def dfs(r: int, c: int, idx: int) -> bool:
+        if idx == len(word):
+            return True
+        if r < 0 or r >= rows or c < 0 or c >= cols:
+            return False
+        if board[r][c] != word[idx]:
+            return False
+
+        temp = board[r][c]
+        board[r][c] = "#"
+
+        found = (
+            dfs(r + 1, c, idx + 1)
+            or dfs(r - 1, c, idx + 1)
+            or dfs(r, c + 1, idx + 1)
+            or dfs(r, c - 1, idx + 1)
+        )
+
+        board[r][c] = temp
+        return found
+
+    for r in range(rows):
+        for c in range(cols):
+            if dfs(r, c, 0):
+                return True
+
+    return False
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
+    print("All tests passed.")


### PR DESCRIPTION
## Problem
Given a character grid and a word, return True if the word exists
in the grid using sequentially adjacent cells without reuse.

## Approach
Backtracking DFS starting from every cell. At each step check if
current cell matches current word character. Mark cell as "#" to
prevent reuse in the same path, then restore after backtracking.
Early exit returns True as soon as word is found.

## Complexity
- Time: O(m * n * 4^L) — L = word length
- Space: O(L) — recursion stack depth

## Closes
Closes #39 